### PR TITLE
Start rewriting multiblocks

### DIFF
--- a/src/main/java/dev/turtywurty/industria/Industria.java
+++ b/src/main/java/dev/turtywurty/industria/Industria.java
@@ -60,6 +60,7 @@ public class Industria implements ModInitializer {
         LOGGER.info("Loading Industria...");
 
         // Registries
+        IndustriaRegistries.init();
         ItemInit.init();
         BlockInit.init();
         BlockEntityTypeInit.init();
@@ -75,6 +76,7 @@ public class Industria implements ModInitializer {
         ComponentTypeInit.init();
         EntityTypeInit.init();
         RecipeBookCategoryInit.init();
+        MultiblockTypeInit.init();
 
         ExtraPacketCodecs.registerDefaults();
 

--- a/src/main/java/dev/turtywurty/industria/init/IndustriaRegistries.java
+++ b/src/main/java/dev/turtywurty/industria/init/IndustriaRegistries.java
@@ -1,0 +1,19 @@
+package dev.turtywurty.industria.init;
+
+import dev.turtywurty.industria.Industria;
+import dev.turtywurty.industria.multiblock.MultiblockType;
+import net.fabricmc.fabric.api.event.registry.FabricRegistryBuilder;
+import net.fabricmc.fabric.api.event.registry.RegistryAttribute;
+import net.minecraft.registry.Registry;
+import net.minecraft.registry.RegistryKey;
+
+public class IndustriaRegistries {
+    public static final RegistryKey<Registry<MultiblockType<?>>> MULTIBLOCK_TYPES_KEY = RegistryKey.ofRegistry(Industria.id("multiblock_types"));
+
+    public static final Registry<MultiblockType<?>> MULTIBLOCK_TYPES =
+            FabricRegistryBuilder.createSimple(MULTIBLOCK_TYPES_KEY)
+                    .attribute(RegistryAttribute.SYNCED)
+                    .buildAndRegister();
+
+    public static void init() {}
+}

--- a/src/main/java/dev/turtywurty/industria/init/MultiblockTypeInit.java
+++ b/src/main/java/dev/turtywurty/industria/init/MultiblockTypeInit.java
@@ -1,0 +1,62 @@
+package dev.turtywurty.industria.init;
+
+import dev.turtywurty.industria.Industria;
+import dev.turtywurty.industria.blockentity.DrillBlockEntity;
+import dev.turtywurty.industria.blockentity.OilPumpJackBlockEntity;
+import dev.turtywurty.industria.multiblock.MultiblockType;
+import net.minecraft.block.entity.BlockEntity;
+import net.minecraft.registry.Registry;
+
+public class MultiblockTypeInit {
+    public static final MultiblockType<OilPumpJackBlockEntity> OIL_PUMP_JACK = register("oil_pump_jack",
+            new MultiblockType.Builder<OilPumpJackBlockEntity>(123)
+                    .setHasDirectionProperty(true)
+                    .setOnPrimaryBlockUse((world, player, hitResult, pos) -> {
+                        if (world.getBlockEntity(pos) instanceof OilPumpJackBlockEntity oilPumpJackBlockEntity) {
+                            oilPumpJackBlockEntity.type().onPrimaryBlockUse(world, player, hitResult, pos);
+                        }
+                    })
+                    .setOnMultiblockBreak((world, pos) -> {
+                        if (world.getBlockEntity(pos) instanceof OilPumpJackBlockEntity oilPumpJackBlockEntity) {
+                            oilPumpJackBlockEntity.type().onMultiblockBreak(world, pos);
+                        }
+                    })
+                    .setEnergyProvider((blockEntity, direction) -> {
+                        return null;
+                    })
+                    .setInventoryProvider((blockEntity, direction) -> {
+                        return null;
+                    })
+                    .setFluidProvider((blockEntity, direction) -> {
+                        return null;
+                    }));
+
+    public static final MultiblockType<DrillBlockEntity> DRILL = register("drill",
+            new MultiblockType.Builder<DrillBlockEntity>(26)
+                    .setHasDirectionProperty(true)
+                    .setOnPrimaryBlockUse((world, player, hitResult, pos) -> {
+                        if (world.getBlockEntity(pos) instanceof DrillBlockEntity drillBlockEntity) {
+                            drillBlockEntity.type().onPrimaryBlockUse(world, player, hitResult, pos);
+                        }
+                    })
+                    .setOnMultiblockBreak((world, pos) -> {
+                        if (world.getBlockEntity(pos) instanceof DrillBlockEntity drillBlockEntity) {
+                            drillBlockEntity.type().onMultiblockBreak(world, pos);
+                        }
+                    })
+                    .setEnergyProvider((blockEntity, direction) -> {
+                        return null;
+                    })
+                    .setInventoryProvider((blockEntity, direction) -> {
+                        return null;
+                    })
+                    .setFluidProvider((blockEntity, direction) -> {
+                        return null;
+                    }));
+
+    public static <T extends BlockEntity> MultiblockType<T> register(String name, MultiblockType.Builder<T> builder) {
+        return Registry.register(IndustriaRegistries.MULTIBLOCK_TYPES, Industria.id(name), builder.build());
+    }
+
+    public static void init() {}
+}


### PR DESCRIPTION
- Switch enum to a registry
- Create a MultiblockType builder
- Remove toString and fromString methods
- Make MultiblockType generic of type BlockEntity