### PR TITLE
Fix heat pipe storage registration bug

### DIFF
--- a/src/main/java/dev/turtywurty/industria/Industria.java
+++ b/src/main/java/dev/turtywurty/industria/Industria.java
@@ -189,8 +189,8 @@ public class Industria implements ModInitializer {
         }, BlockInit.SLURRY_PIPE);
 
         HeatStorage.SIDED.registerForBlocks((world, pos, state, blockEntity, context) -> {
-            if(world instanceof ServerWorld serverWorld) {
-                WorldPipeNetworks.getOrCreate(serverWorld).getStorage(TransferType.HEAT, pos);
+            if (world instanceof ServerWorld serverWorld) {
+                return WorldPipeNetworks.getOrCreate(serverWorld).getStorage(TransferType.HEAT, pos);
             }
 
             return null;


### PR DESCRIPTION
## Summary
- fix missing return for heat pipe storage registration

## Testing
- `./gradlew build -x test` *(fails: Plugin [id: 'fabric-loom', version: '1.10.1'] was not found)*

------
https://chatgpt.com/codex/tasks/task_e_684044343e78832f94cb129d5af37ab6